### PR TITLE
Add a priority to the TextureMap mixin

### DIFF
--- a/src/main/java/com/falsepattern/falsetweaks/mixin/mixins/client/animfix/TextureMap_CommonMixin.java
+++ b/src/main/java/com/falsepattern/falsetweaks/mixin/mixins/client/animfix/TextureMap_CommonMixin.java
@@ -41,7 +41,7 @@ import net.minecraft.client.renderer.texture.TextureUtil;
 
 import java.util.List;
 
-@Mixin(TextureMap.class)
+@Mixin(value = TextureMap.class, priority = 998)
 public abstract class TextureMap_CommonMixin implements ITextureMapMixin {
     @Shadow
     private int mipmapLevels;
@@ -68,17 +68,17 @@ public abstract class TextureMap_CommonMixin implements ITextureMapMixin {
     }
 
     @Redirect(method = "loadTextureAtlas",
-              at = @At(value = "INVOKE",
-                       target = "Ljava/util/List;add(Ljava/lang/Object;)Z",
-                       ordinal = 0),
-              require = 1)
+            at = @At(value = "INVOKE",
+                    target = "Ljava/util/List;add(Ljava/lang/Object;)Z",
+                    ordinal = 0),
+            require = 1)
     private boolean storeAnimatedInBatch(List<TextureAtlasSprite> listAnimatedSprites, Object obj) {
         TextureAtlasSprite sprite = (TextureAtlasSprite) obj;
         listAnimatedSprites.add(sprite);
-        AnimationUpdateBatcherRegistry.batcher = batcher;
-        TextureUtil.uploadTextureMipmap(sprite.getFrameTextureData(0), sprite.getIconWidth(), sprite.getIconHeight(),
-                                        sprite.getOriginX(), sprite.getOriginY(), false, false);
-        AnimationUpdateBatcherRegistry.batcher = null;
+                AnimationUpdateBatcherRegistry.batcher = batcher;
+            TextureUtil.uploadTextureMipmap(sprite.getFrameTextureData(0), sprite.getIconWidth(), sprite.getIconHeight(),
+                    sprite.getOriginX(), sprite.getOriginY(), false, false);
+            AnimationUpdateBatcherRegistry.batcher = null;
         return true;
     }
 

--- a/src/main/java/com/falsepattern/falsetweaks/mixin/mixins/client/animfix/TextureMap_CommonMixin.java
+++ b/src/main/java/com/falsepattern/falsetweaks/mixin/mixins/client/animfix/TextureMap_CommonMixin.java
@@ -41,7 +41,7 @@ import net.minecraft.client.renderer.texture.TextureUtil;
 
 import java.util.List;
 
-@Mixin(value = TextureMap.class, priority = 998)
+@Mixin(value = TextureMap.class, priority = 1000)
 public abstract class TextureMap_CommonMixin implements ITextureMapMixin {
     @Shadow
     private int mipmapLevels;


### PR DESCRIPTION
Add a priority to the TextureMap mixin to fix crash on startup with speedupanimations from hodgepodge.

I don't know if its a proper fix.But its work on my 800+ mods modpack.